### PR TITLE
bin path change

### DIFF
--- a/init.d/acpid
+++ b/init.d/acpid
@@ -3,7 +3,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 extra_started_commands="reload"
-command="/usr/sbin/acpid"
+command="/usr/bin/acpid"
 command_args="${ACPID_ARGS}"
 start_stop_daemon_args="--quiet"
 description="Daemon for Advanced Configuration and Power Interface"

--- a/init.d/syslog-ng
+++ b/init.d/syslog-ng
@@ -36,7 +36,7 @@ start() {
     checkconfig || return 1
     ebegin "Starting syslog-ng"
     [ -n "${SYSLOG_NG_OPTS}" ] && SYSLOG_NG_OPTS="-- ${SYSLOG_NG_OPTS}"
-    start-stop-daemon --start --pidfile /run/syslog-ng.pid --exec /usr/sbin/syslog-ng ${SYSLOG_NG_OPTS}
+    start-stop-daemon --start --pidfile /run/syslog-ng.pid --exec /usr/bin/syslog-ng ${SYSLOG_NG_OPTS}
     eend $? "Failed to start syslog-ng"
 }
 


### PR DESCRIPTION
arch devs changed the bin path of syslog-ng and acpid, services fail to start.
