### PR TITLE
Create consolekit.in

### DIFF
--- a/init.d/consolekit.in
+++ b/init.d/consolekit.in
@@ -1,0 +1,26 @@
+#!@RUNSCRIPT@
+# Copyright 1999-2011 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License, v2 or later
+# $Header: /var/cvsroot/gentoo-x86/sys-auth/consolekit/files/consolekit-0.2.rc,v 1.1 2011/10/20 19:14:47 axs Exp $
+
+depend() {
+	need dbus
+	use logger
+}
+
+start() {
+	ebegin "Starting ConsoleKit daemon"
+
+	checkpath -q -d -m 0755 /var/run/ConsoleKit
+
+	start-stop-daemon --start -q \
+		--pidfile /var/run/ConsoleKit/pid \
+		--exec /usr/sbin/console-kit-daemon -- 
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping ConsoleKit daemon"
+	start-stop-daemon --stop -q --pidfile /var/run/ConsoleKit/pid 
+	eend $?
+}

--- a/init.d/consolekit.in
+++ b/init.d/consolekit.in
@@ -11,16 +11,16 @@ depend() {
 start() {
 	ebegin "Starting ConsoleKit daemon"
 
-	checkpath -q -d -m 0755 /var/run/ConsoleKit
+	checkpath -q -d -m 0755 /run/ConsoleKit
 
 	start-stop-daemon --start -q \
-		--pidfile /var/run/ConsoleKit/pid \
-		--exec /usr/sbin/console-kit-daemon -- 
+		--pidfile /run/ConsoleKit/pid \
+		--exec /usr/bin/console-kit-daemon -- 
 	eend $?
 }
 
 stop() {
 	ebegin "Stopping ConsoleKit daemon"
-	start-stop-daemon --stop -q --pidfile /var/run/ConsoleKit/pid 
+	start-stop-daemon --stop -q --pidfile /run/ConsoleKit/pid 
 	eend $?
 }


### PR DESCRIPTION
Some people still use consolekit (https://github.com/ConsoleKit2/ConsoleKit2) as logind doesn't work without systemd as PID1.