### PR TITLE
Create consolekit.in

### DIFF
--- a/init.d/consolekit.in
+++ b/init.d/consolekit.in
@@ -1,0 +1,25 @@
+#!@RUNSCRIPT@
+# Copyright 1999-2011 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License, v2 or later
+
+depend() {
+    need dbus
+    use logger
+}
+
+start() {
+    ebegin "Starting ConsoleKit daemon"
+
+    checkpath -q -d -m 0755 /run/ConsoleKit
+
+    start-stop-daemon --start -q \
+		      --pidfile /run/ConsoleKit/pid \
+		      --exec /usr/bin/console-kit-daemon -- 
+    eend $?
+}
+
+stop() {
+    ebegin "Stopping ConsoleKit daemon"
+    start-stop-daemon --stop -q --pidfile /run/ConsoleKit/pid 
+    eend $?
+}


### PR DESCRIPTION
Some people still use consolekit (https://github.com/ConsoleKit2/ConsoleKit2) as logind doesn't work without systemd as PID1.