### PR TITLE
Add iwd service file from Gentoo

### DIFF
--- a/init.d/iwd.in
+++ b/init.d/iwd.in
@@ -1,0 +1,12 @@
+#!/usr/bin/openrc-run
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+pidfile="/run/iwd.pid"
+command="/usr/lib/iwd/iwd"
+command_background="yes"
+
+depend() {
+    need dbus
+    keyword -shutdown
+}


### PR DESCRIPTION
I added and tested a simple file for starting iwd. This might have relatively high demand since it is a self-contained program that doesn't use wpa_supplicant.